### PR TITLE
Fix preposition for clarity in Circom integration description

### DIFF
--- a/2024/week1_cryptographic_basics.md
+++ b/2024/week1_cryptographic_basics.md
@@ -7,7 +7,7 @@ In each of our modules, we will have a practical component so that you can get s
 ### Getting Started with Circom
 
 #### Understanding how a Circom circuit integrates to a system or application
-Let's see the workflow to have an overview of how a Circom circuit integrates to an App project:
+Let's see the workflow to have an overview of how a Circom circuit integrates into an App project:
 ```mermaid
 sequenceDiagram
     participant Developer


### PR DESCRIPTION
This change fixes a small but important grammar issue. The verb “integrate” should be followed by “into” rather than “to” when referring to a system or project. This makes the sentence more natural and technically correct for English readers.