### PR TITLE
Fix broken repository link: replace zk-email-minimal with official zk…

### DIFF
--- a/2024/contributions/README.md
+++ b/2024/contributions/README.md
@@ -405,7 +405,7 @@ Zk-mercadopago
 Create a circom circuit that proves a transaction over mercadopago payment system
 
 **GitHub Link:**
-[https://github.com/yagopajarino/zk-email-minimal](https://github.com/yagopajarino/zk-email-minimal)
+[https://github.com/zkemail/zk-email-verify](https://github.com/zkemail/zk-email-verify)
 
 ---
 


### PR DESCRIPTION
### Description

This PR fixes a broken repository link in the project. The previously referenced repository (yagopajarino/zk-email-minimal) is no longer available or has been moved. 

Changes:
- Replaced https://github.com/yagopajarino/zk-email-minimal with https://github.com/zkemail/zk-email-verify
- Updated to point to the official ZK Email repository which is actively maintained


### Type of Change

- [ ] Typo/grammar fix
- [ ] Code correction (e.g., a bug in a code snippet)
- [ ] New tutorial or section
- [ ] Other (please describe):

### Checklist

- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to related documentation.
